### PR TITLE
Equivariant Filter Optimizations (?)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _build
 GEMINI.md
 doc/#*.lyx#
 /cmake-build-debug/
+.venv/

--- a/examples/AbcEquivariantFilterExample.cpp
+++ b/examples/AbcEquivariantFilterExample.cpp
@@ -17,6 +17,7 @@ constexpr size_t n = 1;  // Number of calibration states
 using M = abc_eqf_lib::State<n>;
 using G = abc_eqf_lib::Group<n>;
 using EqFilter = gtsam::EqF<G, M>;
+using Geometry = ABCGeometry<n>;
 using gtsam::abc_eqf_lib::InputData;
 using gtsam::abc_eqf_lib::Measurement;
 
@@ -253,7 +254,7 @@ void processDataWithEqF(EqFilter& filter, const std::vector<Data>& data_list,
 
   for (size_t i = 0; i < data_list.size(); i++) {
     const Data& data = data_list[i];
-    Matrix Q   = Geometry::processNoise(data.u);
+    Matrix Q = Geometry::processNoise(data.u.Sigma);
     // Propagate filter with current input and time step
     filter.predict(data.u.toInputVector(), Q, data.dt);
 

--- a/examples/AbcEquivariantFilterExample.cpp
+++ b/examples/AbcEquivariantFilterExample.cpp
@@ -16,8 +16,7 @@ using namespace gtsam::abc_eqf_lib;
 constexpr size_t n = 1;  // Number of calibration states
 using M = abc_eqf_lib::State<n>;
 using G = abc_eqf_lib::Group<n>;
-using Geometry = ABCGeometry<n>;
-using EqFilter = gtsam::EqF<G, M, Geometry>; 
+using EqFilter = gtsam::EqF<G, M>;
 using gtsam::abc_eqf_lib::InputData;
 using gtsam::abc_eqf_lib::Measurement;
 
@@ -431,7 +430,7 @@ int main(int argc, char* argv[]) {
         Vector3::Constant(0.1);  // Calibration uncertainty
 
     G initialGroup = gtsam::traits<G>::Identity();
-    M initialState = Geometry::identityState();
+    M initialState = M::identity();
 
     // Create filter
     EqFilter filter(initialGroup, initialState, initialSigma, N);

--- a/gtsam/navigation/EquivariantFilter.h
+++ b/gtsam/navigation/EquivariantFilter.h
@@ -39,155 +39,154 @@ using namespace std;
 using namespace gtsam;
 
 //========================================================================
-// Equivariant Filter (EqF) Template Function Verification
+// Equivariant Filter (EqF) Template Function Verification (verify)
 //========================================================================
-template <typename Geometry, typename M>
-class has_lift {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::lift(std::declval<M>(), std::declval<typename G::InputType>()),
-                  std::true_type{});
+// template <typename Geometry, typename M>
+// class has_lift {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::lift(std::declval<M>(), std::declval<typename G::InputType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_groupAction {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::groupAction(std::declval<typename G::GType>(),
-                                 std::declval<typename G::MType>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_groupAction {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::groupAction(std::declval<typename G::GType>(),
+//                                  std::declval<typename G::MType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_stateTransitionMatrix {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::stateTransitionMatrix(std::declval<typename G::InputData>(),
-                                           std::declval<double>(),
-                                           std::declval<typename G::GType>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_stateTransitionMatrix {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::stateTransitionMatrix(std::declval<typename G::InputData>(),
+//                                            std::declval<double>(),
+//                                            std::declval<typename G::GType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_stateMatrixA {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::stateMatrixA(std::declval<const typename G::GType&>(),
-                                  std::declval<const typename G::InputDataType&>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_stateMatrixA {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::stateMatrixA(std::declval<const typename G::GType&>(),
+//                                   std::declval<const typename G::InputDataType&>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_inputMatrix {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::inputMatrix(std::declval<typename G::GType>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_inputMatrix {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::inputMatrix(std::declval<typename G::GType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_processNoise {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::processNoise(std::declval<const typename G::InputDataType&>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_processNoise {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::processNoise(std::declval<const typename G::InputDataType&>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_inputMatrixBt {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::inputMatrixBt(std::declval<typename G::GType>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_inputMatrixBt {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::inputMatrixBt(std::declval<typename G::GType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_measurementMatrixC {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::measurementMatrixC(std::declval<const Unit3&>(),
-                                        std::declval<int>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_measurementMatrixC {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::measurementMatrixC(std::declval<const Unit3&>(),
+//                                         std::declval<int>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
-template <typename Geometry>
-class has_outputMatrixDt {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::outputMatrixDt(std::declval<int>(),
-                                    std::declval<typename G::GType>()),
-                  std::true_type{});
+// template <typename Geometry>
+// class has_outputMatrixDt {
+//  private:
+//   template <typename G>
+//   static auto test(int)
+//       -> decltype(G::outputMatrixDt(std::declval<int>(),
+//                                     std::declval<typename G::GType>()),
+//                   std::true_type{});
 
-  template <typename>
-  static std::false_type test(...);
+//   template <typename>
+//   static std::false_type test(...);
 
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
+//  public:
+//   static constexpr bool value = decltype(test<Geometry>(0))::value;
+// };
 
 //========================================================================
 // Equivariant Filter (EqF)
 //========================================================================
 
-/// Equivariant Filter (EqF) implementation, parameterized only by
-/// the symmetry group G and the physical state manifold M.
+/// Equivariant Filter (EqF) implementation
 template <typename G, typename M>
 class EqF : public LieGroupEKF<G> {
  private:
@@ -200,7 +199,7 @@ class EqF : public LieGroupEKF<G> {
  public:
   /// Degrees of freedom of the Lie group
   static constexpr int DOF = gtsam::traits<G>::dimension;
-  /// Number of calibration states (sensors), expected to be provided by G.
+  /// Number of calibration states (sensors), expected to be provided by G
   static constexpr int n_cal = G::numSensors;
 
   /**
@@ -227,7 +226,7 @@ class EqF : public LieGroupEKF<G> {
    * @param data Input data containing angular velocity and noise
    * @param dt Time step
    */
-  void predict(const typename Geometry::InputType &u, const Matrix &Q, double dt);
+  void predict(const Vector6 &u, const Matrix &Q, double dt);
 
   /**
    * Update the filter state with a direction measurement.
@@ -262,28 +261,28 @@ EqF<G, M>::EqF(const G& X0, const M& x0, const Matrix& Sigma, int m)
         "Number of direction sensors must be at least 2");
   }
 
-  static_assert(has_lift<Geometry, M>::value,
-                "Geometry must implement static lift(const M&, const InputType&)");
+  // static_assert(has_lift<Geometry, M>::value,
+  //               "Geometry must implement static lift(const M&, const InputType&)");
 
-  // static_assert(has_stateTransitionMatrix<Geometry>::value,
-  //               "Geometry must define static stateTransitionMatrix(InputDataType, "
-  //               "double, GType)");
-  static_assert(has_groupAction<Geometry>::value,
-                "Geometry must define groupAction(GType, MType)");
+  // // static_assert(has_stateTransitionMatrix<Geometry>::value,
+  // //               "Geometry must define static stateTransitionMatrix(InputDataType, "
+  // //               "double, GType)");
+  // static_assert(has_groupAction<Geometry>::value,
+  //               "Geometry must define groupAction(GType, MType)");
+  // // static_assert(
+  // //     has_stateMatrixA<Geometry>::value,
+  // //     "Geometry must define static stateMatrixA(const GType&, const InputDataType&)");
+  // static_assert(has_inputMatrix<Geometry>::value,
+  //               "Geometry must define static inputMatrix(GType)");
+  // static_assert(has_processNoise<Geometry>::value,
+  //               "Geometry must define static processNoise(const InputDataType&)");
+  // static_assert(has_inputMatrixBt<Geometry>::value,
+  //               "Geometry must define static inputMatrixBt(GType)");
   // static_assert(
-  //     has_stateMatrixA<Geometry>::value,
-  //     "Geometry must define static stateMatrixA(const GType&, const InputDataType&)");
-  static_assert(has_inputMatrix<Geometry>::value,
-                "Geometry must define static inputMatrix(GType)");
-  static_assert(has_processNoise<Geometry>::value,
-                "Geometry must define static processNoise(const InputDataType&)");
-  static_assert(has_inputMatrixBt<Geometry>::value,
-                "Geometry must define static inputMatrixBt(GType)");
-  static_assert(
-      has_measurementMatrixC<Geometry>::value,
-      "Geometry must define static measurementMatrixC(const Unit3&, int)");
-  static_assert(has_outputMatrixDt<Geometry>::value,
-                "Geometry must define static outputMatrixDt(int, GType)");
+  //     has_measurementMatrixC<Geometry>::value,
+  //     "Geometry must define static measurementMatrixC(const Unit3&, int)");
+  // static_assert(has_outputMatrixDt<Geometry>::value,
+  //               "Geometry must define static outputMatrixDt(int, GType)");
 
   // Compute differential of phi
   Dphi0 = stateActionDiff(xi_ref);
@@ -314,19 +313,15 @@ G EqF<G, M>::groupEstimate() const {
  * Updated internal state and covariance
  */
 template <typename G, typename M>
-template <class InputDataType>
-void EqF<G, M>::predict(const InputDataType& data, double dt) {
+void EqF<G, M>::predict(const Vector6 &u, const Matrix &Q, double dt) {
   // Map current group estimate to physical state on the manifold
   M state_est = stateEstimate();
 
   // Compute lifted tangent vector from state and input
-  Vector L = state_est.lift(data.toInputVector());
+  Vector L = state_est.lift(u);
 
-  // EqF-specific discrete-time propagation and covariance update using
-  // helpers defined for the group and input types (e.g., in ABC.h).
-  Matrix Phi = stateTransitionMatrix(this->X_, data, dt);
+  Matrix Phi = stateTransitionMatrix(this->X_, u, dt);
   Matrix Bt  = inputMatrixBt(this->X_);
-  Matrix Q   = processNoise(this->X_, data);
 
   this->X_ = traits<G>::Compose(this->X_, traits<G>::Expmap(L * dt));
   this->P_ = Phi * this->P_ * Phi.transpose() + Bt * Q * Bt.transpose() * dt;
@@ -367,7 +362,7 @@ void EqF<G, M>::update(const MeasurementType& y) {
   // Use base class to perform update with zero innovation
   Vector3 z_zero = Vector3::Zero();
   Vector3 prediction_zero = Vector3::Zero();
-  auto& baseEKF = static_cast<ManifoldEKF<G>&>(*this);
+  auto& baseEKF = static_cast<ManifoldEKF<G>&>(*this); // not sure if this is the right way to do this (although it works). would be better to inherit from ManifoldEKF
   baseEKF.update(prediction_zero, Ct, z_zero,
                  Dt * y.Sigma * Dt.transpose());
   // Apply EqF state correction with InnovationLift

--- a/gtsam/navigation/EquivariantFilter.h
+++ b/gtsam/navigation/EquivariantFilter.h
@@ -39,192 +39,60 @@ using namespace std;
 using namespace gtsam;
 
 //========================================================================
-// Equivariant Filter (EqF) Template Function Verification
-//========================================================================
-template <typename Geometry, typename M>
-class has_lift {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::lift(std::declval<M>(), std::declval<typename G::InputType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_groupAction {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::groupAction(std::declval<typename G::GType>(),
-                                 std::declval<typename G::MType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_stateTransitionMatrix {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::stateTransitionMatrix(std::declval<typename G::InputDataType>(),
-                                           std::declval<double>(),
-                                           std::declval<typename G::GType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_stateMatrixA {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::stateMatrixA(std::declval<const typename G::GType&>(),
-                                  std::declval<const typename G::InputDataType&>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_inputMatrix {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::inputMatrix(std::declval<typename G::GType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_processNoise {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::processNoise(std::declval<const typename G::InputDataType&>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_inputMatrixBt {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::inputMatrixBt(std::declval<typename G::GType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_measurementMatrixC {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::measurementMatrixC(std::declval<const Unit3&>(),
-                                        std::declval<int>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-template <typename Geometry>
-class has_outputMatrixDt {
- private:
-  template <typename G>
-  static auto test(int)
-      -> decltype(G::outputMatrixDt(std::declval<int>(),
-                                    std::declval<typename G::GType>()),
-                  std::true_type{});
-
-  template <typename>
-  static std::false_type test(...);
-
- public:
-  static constexpr bool value = decltype(test<Geometry>(0))::value;
-};
-
-//========================================================================
 // Equivariant Filter (EqF)
 //========================================================================
 
-/// Equivariant Filter (EqF) implementation
-template <typename G, typename M, typename Geometry>
+/// Equivariant Filter (EqF) implementation, parameterized only by
+/// the symmetry group G and the physical state manifold M.
+template <typename G, typename M>
 class EqF : public LieGroupEKF<G> {
  private:
-  M xi_ref;                 // Origin state
-  Matrix Dphi0;           // Differential of phi at origin
+  using LGBase = LieGroupEKF<G>;
+
+  M xi_ref;           // Origin (reference) state on the manifold
+  Matrix Dphi0;       // Differential of the state action at origin
   Matrix InnovationLift;  // Innovation lift matrix
 
  public:
+  /// Degrees of freedom of the Lie group
+  static constexpr int DOF = gtsam::traits<G>::dimension;
+  /// Number of calibration states (sensors), expected to be provided by G.
+  static constexpr int n_cal = G::numSensors;
+
   /**
    * Initialize EqF
-   * @param Sigma Initial covariance
-   * @param m Number of sensors
+   * @param X0 Initial Lie group state
+   * @param x0 Reference manifold state (origin of the lifted coordinates)
+   * @param Sigma Initial covariance (DOF x DOF)
+   * @param m Number of direction sensors (must be at least 2)
    */
   EqF(const G& X0, const M& x0, const Matrix& Sigma, int m);
 
   /**
-   * Return estimated state
-   * @return Current state estimate
+   * Return estimated physical state on manifold M.
+   * Applies the group action of the current group estimate on the origin state.
    */
   M stateEstimate() const;
 
+  /// Return the current group estimate.
   G groupEstimate() const;
 
-   /**
-   * Propagate the filter state
+  /**
+   * Propagate the filter state.
+   * @tparam InputDataType Type holding input measurements with noise (e.g., InputData).
    * @param data Input data containing angular velocity and noise
    * @param dt Time step
    */
-  void predict(const typename Geometry::InputDataType& data, double dt);
+  template <class InputDataType>
+  void predict(const InputDataType& data, double dt);
 
   /**
-   * Update the filter state with a measurement
+   * Update the filter state with a direction measurement.
+   * @tparam MeasurementType Measurement type (must expose y, d, Sigma, cal_idx).
    * @param y Direction measurement
    */
-  void update(const typename Geometry::Measurement& y);
-
-  static constexpr int DOF = gtsam::traits<G>::dimension;
-  static constexpr int n_cal = Geometry::n_cal;
+  template <class MeasurementType>
+  void update(const MeasurementType& y);
 };
 
 //========================================================================
@@ -238,46 +106,18 @@ class EqF : public LieGroupEKF<G> {
  * @param m Number of sensors
  * Uses SelfAdjointSolver, completeOrthoganalDecomposition().pseudoInverse()
  */
-template <typename G, typename M, typename Geometry>
-EqF<G, M, Geometry>::EqF(const G& X0, const M& x0, const Matrix& Sigma, int m) : LieGroupEKF<G>(X0, Sigma),
-    xi_ref(x0) {
+template <typename G, typename M>
+EqF<G, M>::EqF(const G& X0, const M& x0, const Matrix& Sigma, int m)
+    : LGBase(X0, Sigma), xi_ref(x0) {
   if (Sigma.rows() != DOF || Sigma.cols() != DOF) {
     throw std::invalid_argument(
         "Initial covariance dimensions must match the degrees of freedom");
-  }
-
-  if (n_cal < 0) {
-    throw std::invalid_argument(
-        "Number of calibration states must be non-negative");
   }
 
   if (m <= 1) {
     throw std::invalid_argument(
         "Number of direction sensors must be at least 2");
   }
-
-  static_assert(has_lift<Geometry, M>::value,
-                "Geometry must implement static lift(const M&, const InputType&)");
-
-  static_assert(has_stateTransitionMatrix<Geometry>::value,
-                "Geometry must define static stateTransitionMatrix(InputDataType, "
-                "double, GType)");
-  static_assert(has_groupAction<Geometry>::value,
-                "Geometry must define groupAction(GType, MType)");
-  static_assert(
-      has_stateMatrixA<Geometry>::value,
-      "Geometry must define static stateMatrixA(const GType&, const InputDataType&)");
-  static_assert(has_inputMatrix<Geometry>::value,
-                "Geometry must define static inputMatrix(GType)");
-  static_assert(has_processNoise<Geometry>::value,
-                "Geometry must define static processNoise(const InputDataType&)");
-  static_assert(has_inputMatrixBt<Geometry>::value,
-                "Geometry must define static inputMatrixBt(GType)");
-  static_assert(
-      has_measurementMatrixC<Geometry>::value,
-      "Geometry must define static measurementMatrixC(const Unit3&, int)");
-  static_assert(has_outputMatrixDt<Geometry>::value,
-                "Geometry must define static outputMatrixDt(int, GType)");
 
   // Compute differential of phi
   Dphi0 = stateActionDiff(xi_ref);
@@ -287,14 +127,15 @@ EqF<G, M, Geometry>::EqF(const G& X0, const M& x0, const Matrix& Sigma, int m) :
  * Computes the internal group state to a physical state estimate
  * @return Current state estimate
  */
-template <typename G, typename M, typename Geometry>
-M EqF<G, M, Geometry>::stateEstimate() const {
-  return Geometry::groupAction(this->X_, xi_ref);
+template <typename G, typename M>
+M EqF<G, M>::stateEstimate() const {
+  // Group action X * xi_ref (defined for ABC as Group * State).
+  return this->X_ * xi_ref;
 }
 
 
-template <typename G, typename M, typename Geometry>
-G EqF<G, M, Geometry>::groupEstimate() const {
+template <typename G, typename M>
+G EqF<G, M>::groupEstimate() const {
  return this->X_;
 }
 
@@ -306,21 +147,22 @@ G EqF<G, M, Geometry>::groupEstimate() const {
  * @param dt time steps
  * Updated internal state and covariance
  */
-template <typename G, typename M, typename Geometry>
-void EqF<G, M, Geometry>::predict(const typename Geometry::InputDataType& data,
-                                      double dt) {
-  M state_est = stateEstimate();                    // your manifold version
-  Vector L = Geometry::lift(state_est, data.toInputVector());  // tangent vector
+template <typename G, typename M>
+template <class InputDataType>
+void EqF<G, M>::predict(const InputDataType& data, double dt) {
+  // Map current group estimate to physical state on the manifold
+  M state_est = stateEstimate();
 
+  // Compute lifted tangent vector from state and input
+  Vector L = state_est.lift(data.toInputVector());
 
-  Matrix Phi = Geometry::stateTransitionMatrix(data, dt, this->X_);
-  Matrix Bt  = Geometry::inputMatrixBt(this->X_);
-  Matrix Q   = Geometry::processNoise(data);
-
+  // EqF-specific discrete-time propagation and covariance update using
+  // helpers defined for the group and input types (e.g., in ABC.h).
+  Matrix Phi = stateTransitionMatrix(this->X_, data, dt);
+  Matrix Bt  = inputMatrixBt(this->X_);
+  Matrix Q   = processNoise(this->X_, data);
 
   this->X_ = traits<G>::Compose(this->X_, traits<G>::Expmap(L * dt));
-
-
   this->P_ = Phi * this->P_ * Phi.transpose() + Bt * Q * Bt.transpose() * dt;
 }
 /**
@@ -330,8 +172,9 @@ void EqF<G, M, Geometry>::predict(const typename Geometry::InputDataType& data,
  *
  * @param y Measurements
  */
-template <typename G, typename M, typename Geometry>
-void EqF<G, M, Geometry>::update(const typename Geometry::Measurement& y) {
+template <typename G, typename M>
+template <class MeasurementType>
+void EqF<G, M>::update(const MeasurementType& y) {
   if (y.cal_idx > static_cast<int>(n_cal)) {
     throw std::invalid_argument("Calibration index out of range");
   }
@@ -346,17 +189,24 @@ void EqF<G, M, Geometry>::update(const typename Geometry::Measurement& y) {
     return;  // Skip this measurement
   }
 
-  Matrix Ct = Geometry::measurementMatrixC(y.d, y.cal_idx);
+  Matrix Ct = measurementMatrixC(y.d, y.cal_idx, this->X_);
 
   Vector3 action_result = outputAction(this->X_.inv(), y.y, y.cal_idx);
   Vector3 delta_vec = Rot3::Hat(y.d.unitVector()) * action_result;
-  Matrix Dt = Geometry::outputMatrixDt(y.cal_idx, this->X_);
+  Matrix Dt = outputMatrixDt(this->X_, y.cal_idx);
 
   Matrix S = Ct * this->P_ * Ct.transpose() + Dt * y.Sigma * Dt.transpose();
   Matrix K = this->P_ * Ct.transpose() * S.inverse();
+  
+  // Use base class to perform update with zero innovation
+  Vector3 z_zero = Vector3::Zero();
+  Vector3 prediction_zero = Vector3::Zero();
+  auto& baseEKF = static_cast<ManifoldEKF<G>&>(*this);
+  baseEKF.update(prediction_zero, Ct, z_zero,
+                 Dt * y.Sigma * Dt.transpose());
+  // Apply EqF state correction with InnovationLift
   Vector Delta = InnovationLift * K * delta_vec;
   this->X_ = traits<G>::Compose(traits<G>::Expmap(Delta), this->X_);
-  this->P_ = (Matrix::Identity(DOF, DOF) - K * Ct) * this->P_;
 }
 }  // namespace gtsam
 

--- a/gtsam_unstable/geometry/ABC.h
+++ b/gtsam_unstable/geometry/ABC.h
@@ -408,7 +408,6 @@ Matrix stateActionDiff(const State<N>& xi) {
 template <size_t N>
 struct ABCGeometry {
   using InputType = Vector6;  // Mathematical input (ω, 0)
-  using InputDataType = abc_eqf_lib::InputData;  // Data with noise params
   using Measurement = abc_eqf_lib::Measurement;
   using GType = Group<N>;
   using MType = State<N>;
@@ -428,13 +427,16 @@ struct ABCGeometry {
     return xi.lift(u);
   }
 
+
   /**
    * Computes the discrete time state transition matrix
-   * @param data Input data containing angular velocity and noise
+   * @param u Angular velocity
    * @param dt time step
    * @return State transition matrix in discrete time
    */
-  static Matrix stateTransitionMatrix(const Vector6 &u, double dt, GType X_hat) {
+  // TODO: new version of this function reduces precision, fails ABCGeometry_stateTransitionMatrix test case as a result
+  static Matrix stateTransitionMatrix(const Vector6& u, double dt, 
+                                      GType X_hat) {
     Matrix A = stateMatrixA(X_hat, u);
     Matrix I = Matrix::Identity(A.rows(), A.cols());
 
@@ -444,6 +446,7 @@ struct ABCGeometry {
     return I + dt * A + 0.5 * dt * dt * A2 + (1.0 / 6.0) * dt * dt * dt * A3;
     //return (A * dt).exp().eval();
   }
+
   /**
    * Computes linearized continuous time state matrix
    * @param data Input data
@@ -471,8 +474,8 @@ struct ABCGeometry {
     return blockDiag(B1, B2);
   }
 
-  static Matrix processNoise(const InputDataType& data) {
-    return blockDiag(data.Sigma, repBlock(1e-9 * I_3x3, N));
+  static Matrix processNoise(const Matrix &Sigma) {
+    return blockDiag(Sigma, repBlock(1e-9 * I_3x3, N));
   }
 
   /**
@@ -543,20 +546,18 @@ static Matrix measurementMatrixC(const Unit3& d, int idx) {
 /**
  * @brief Discrete-time state transition matrix for the EqF.
  *
- * Thin wrapper around ABCGeometry<N>::stateTransitionMatrix so that generic
- * code (e.g., the EqF implementation) can call this via ADL using only the
- * group type G = Group<N> and the input data type.
+ * Thin wrapper around ABCGeometry<N>::stateTransitionMatrix
  */
 template <size_t N>
-Matrix stateTransitionMatrix(const Group<N>& X_hat, const InputData& data,
+Matrix stateTransitionMatrix(const Group<N>& X_hat, const Vector6 &u,
                              double dt) {
-  return ABCGeometry<N>::stateTransitionMatrix(data, dt, X_hat);
+  return ABCGeometry<N>::stateTransitionMatrix(u, dt, X_hat);
 }
 
 /**
  * @brief Input uncertainty propagation matrix Bt for the EqF.
  *
- * Wraps ABCGeometry<N>::inputMatrixBt for use via ADL.
+ * Wraps ABCGeometry<N>::inputMatrixBt
  */
 template <size_t N>
 Matrix inputMatrixBt(const Group<N>& X_hat) {
@@ -566,7 +567,7 @@ Matrix inputMatrixBt(const Group<N>& X_hat) {
 /**
  * @brief Continuous-time process noise covariance in lifted coordinates.
  *
- * Wraps ABCGeometry<N>::processNoise for use with ADL
+ * Wraps ABCGeometry<N>::processNoise
  */
 template <size_t N>
 Matrix processNoise(const Group<N>& /*X_hat*/, const InputData& data) {
@@ -576,7 +577,7 @@ Matrix processNoise(const Group<N>& /*X_hat*/, const InputData& data) {
 /**
  * @brief Linearized measurement matrix C for a direction measurement.
  *
- * Wraps ABCGeometry<N>::measurementMatrixC for use with ADL
+ * Wraps ABCGeometry<N>::measurementMatrixC
  */
 template <size_t N>
 Matrix measurementMatrixC(const Unit3& d, int idx, const Group<N>& /*X_hat*/) {
@@ -586,7 +587,7 @@ Matrix measurementMatrixC(const Unit3& d, int idx, const Group<N>& /*X_hat*/) {
 /**
  * @brief Measurement uncertainty propagation matrix Dt.
  *
- * Wraps ABCGeometry<N>::outputMatrixDt for use with ADL
+ * Wraps ABCGeometry<N>::outputMatrixDt
  */
 template <size_t N>
 Matrix outputMatrixDt(const Group<N>& X_hat, int idx) {

--- a/gtsam_unstable/geometry/ABC.h
+++ b/gtsam_unstable/geometry/ABC.h
@@ -541,6 +541,63 @@ static Matrix measurementMatrixC(const Unit3& d, int idx) {
   static constexpr int n_cal = N;
 };
 
+//========================================================================
+// Free-function adapters for EqF and generic EKF code
+//========================================================================
+
+/**
+ * @brief Discrete-time state transition matrix for the EqF.
+ *
+ * Thin wrapper around ABCGeometry<N>::stateTransitionMatrix so that generic
+ * code (e.g., the EqF implementation) can call this via ADL using only the
+ * group type G = Group<N> and the input data type.
+ */
+template <size_t N>
+Matrix stateTransitionMatrix(const Group<N>& X_hat, const InputData& data,
+                             double dt) {
+  return ABCGeometry<N>::stateTransitionMatrix(data, dt, X_hat);
+}
+
+/**
+ * @brief Input uncertainty propagation matrix Bt for the EqF.
+ *
+ * Wraps ABCGeometry<N>::inputMatrixBt for use via ADL.
+ */
+template <size_t N>
+Matrix inputMatrixBt(const Group<N>& X_hat) {
+  return ABCGeometry<N>::inputMatrixBt(X_hat);
+}
+
+/**
+ * @brief Continuous-time process noise covariance in lifted coordinates.
+ *
+ * Wraps ABCGeometry<N>::processNoise for use with ADL
+ */
+template <size_t N>
+Matrix processNoise(const Group<N>& /*X_hat*/, const InputData& data) {
+  return ABCGeometry<N>::processNoise(data);
+}
+
+/**
+ * @brief Linearized measurement matrix C for a direction measurement.
+ *
+ * Wraps ABCGeometry<N>::measurementMatrixC for use with ADL
+ */
+template <size_t N>
+Matrix measurementMatrixC(const Unit3& d, int idx, const Group<N>& /*X_hat*/) {
+  return ABCGeometry<N>::measurementMatrixC(d, idx);
+}
+
+/**
+ * @brief Measurement uncertainty propagation matrix Dt.
+ *
+ * Wraps ABCGeometry<N>::outputMatrixDt for use with ADL
+ */
+template <size_t N>
+Matrix outputMatrixDt(const Group<N>& X_hat, int idx) {
+  return ABCGeometry<N>::outputMatrixDt(idx, X_hat);
+}
+
 }  // namespace abc_eqf_lib
 
 template <size_t N>

--- a/gtsam_unstable/geometry/tests/testABC.cpp
+++ b/gtsam_unstable/geometry/tests/testABC.cpp
@@ -406,9 +406,8 @@ TEST(ABC, ABCGeometry_stateMatrixA) {
     u_data.w = (Vector(3) << 0.5, 0.6, 0.7).finished();
     u_data.Sigma = I_6x6;
 
-    Matrix A_matrix = ABCGeometryN::stateMatrixA(X_hat, u_data);
-
     Vector6 u = u_data.toInputVector();
+    Matrix A_matrix = ABCGeometryN::stateMatrixA(X_hat, u);
     Matrix3 W0 = Rot3::Hat(velocityAction(X_hat.inverse(), u).head<3>());
 
     Matrix expected_A1 = Matrix::Zero(6, 6);
@@ -438,9 +437,8 @@ TEST(ABC, ABCGeometry_stateTransitionMatrix) {
 
     double dt = 0.1;
 
-    Matrix Phi = ABCGeometryN::stateTransitionMatrix(u_data, dt, X_hat);
-
     Vector6 u = u_data.toInputVector();
+    Matrix Phi = ABCGeometryN::stateTransitionMatrix(u, dt, X_hat);
     Matrix3 W0 = Rot3::Hat(velocityAction(X_hat.inv(), u).head<3>());
     Matrix Phi1 = Matrix::Zero(6, 6);
     Matrix3 Phi12 = -dt * (I_3x3 + (dt / 2) * W0 + ((dt * dt) / 6) * W0 * W0);
@@ -491,7 +489,7 @@ TEST(ABC, ABCGeometry_processNoise) {
         0, 0, 0, 0, 5, 0,
         0, 0, 0, 0, 0, 6).finished();
 
-    Matrix Q = ABCGeometryN::processNoise(u_data);
+    Matrix Q = ABCGeometryN::processNoise(u_data.Sigma);
 
     Matrix expected_Q_cal_part = repBlock(1e-9 * I_3x3, N_TEST);
     Matrix expected_Q = blockDiag(u_data.Sigma, expected_Q_cal_part);
@@ -570,7 +568,9 @@ TEST(ABC, EqFilter){
 	u.Sigma = I_6x6;
 	double dt = 0.01;
 
-	filter.predict(u, dt);
+    Vector6 u_vec = u.toInputVector();
+    Matrix Q = ABCGeometryN::processNoise(u.Sigma);
+    filter.predict(u_vec, Q, dt);
 
 	EXPECT(traits<G>::Equals(filter.groupEstimate(), filter.state(), 1e-9));
   }

--- a/gtsam_unstable/geometry/tests/testABC.cpp
+++ b/gtsam_unstable/geometry/tests/testABC.cpp
@@ -8,7 +8,7 @@
 #include <gtsam/base/testLie.h>
 #include <CppUnitLite/TestHarness.h>
 
-#include <gtsam_unstable/geometry/ABC.h> // Include your ABC.h file
+#include <gtsam_unstable/geometry/ABC.h>
 #include <gtsam/navigation/EquivariantFilter.h>
 
 using namespace gtsam;
@@ -541,8 +541,7 @@ TEST(ABC, ABCGeometry_processNoise) {
 TEST(ABC, EqFilter){
     using M = abc_eqf_lib::State<N_TEST>;
     using G = abc_eqf_lib::Group<N_TEST>;
-    using Geometry = ABCGeometry<N_TEST>;
-    using EqFilter = abc_eqf_lib::EqF<G, M, Geometry>;
+    using EqFilter = gtsam::EqF<G, M>;
     
     const G g_0;
     const M xi_ref; // Reference state (xi circle) and not inital state?
@@ -565,8 +564,8 @@ TEST(ABC, EqFilter){
     EXPECT(traits<G>::Equals(g_0, X_HatActual, 1e-9));
 
     EXPECT(traits<G>::Equals(X_HatActual, X_HatExpected, 1e-9));
-    // Next check predict
-    typename Geometry::InputDataType u;
+
+    InputData u;
 	u.w = (Vector3() << 0.01, -0.02, 0.015).finished();
 	u.Sigma = I_6x6;
 	double dt = 0.01;


### PR DESCRIPTION
Currently in progress. 

Current idea:
The ManifoldEKF / LieGroupEKF base classes already give us the generic EKF stuff, the things EqF needs from Geometry are:
- how to lift inputs
- how to compute A, B, Q for prediction
- how to compute C, D for the measurement update and the innovation lift

The main refactor:
- Remove Geometry from EqF’s template parameters
- Move the static methods from ABCGeometry<N> into free funcs State<N>, Group<N>, InputData, and Measurement, so they’re found by ADL
- Rewrite EqF::predict and EqF::update to use State::lift, Group composition, and the free functions

Additionally, I changed the filter update step to use the base class update method then apply InnovationLift correction afterwards.

I may have refactored things that don't make sense, feedback welcomed.